### PR TITLE
Change settings after init

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,22 @@ Let it Snow is a little plugin that is based off the solution of creating a snow
 To add this to your website, simply include the latest jQuery library together with `jquery.let_it_snow.js` into your document's `<head>`, and simply call the function like this:
 
 ````javascript
-  $("canvas").let_it_snow({
-    speed: 0, // How fast the snow falls can be define here. You can choose a number in between 0 - 5. The higher, the faster. The default value is 0.
-    interaction: true, // This option allows viewer to interact with the falling snow. Toggle this to false if you don't want the snow to be interactive. The default value is true.
-    size: 2, // You can set the size of the snow here. Choose a number between 0 - 10+. The higher, the bigger. The default size is 2.
-    count: 200, // This allows you to set the number of snows displayed at a time. The default count is 200.
-    opacity: 0, // The opacity variation of the snow. You can choose a number in between 0.00 and 1.00 to set the base opacity and the plugin will randomly generate snows with slightly varied opacity.
-    color: "#ffffff", // You can set the color of the snow here. This option only accepts HEX color code in full 6 digits. The default value is "#ffffff"
-    windPower: 0, // You can set the wind power here. If you want the wind to blow left, set a positive number in this option., if you want the wind to blow right, set a negative number in this option. The default value is 0.
-    image: false // You can define a path to an image to be used instead of a default circle here. The default value is false.
-  });
+$("canvas").let_it_snow({
+  speed: 0, // How fast the snow falls can be define here. You can choose a number in between 0 - 5. The higher, the faster. The default value is 0.
+  interaction: true, // This option allows viewer to interact with the falling snow. Toggle this to false if you don't want the snow to be interactive. The default value is true.
+  size: 2, // You can set the size of the snow here. Choose a number between 0 - 10+. The higher, the bigger. The default size is 2.
+  count: 200, // This allows you to set the number of snows displayed at a time. The default count is 200.
+  opacity: 0, // The opacity variation of the snow. You can choose a number in between 0.00 and 1.00 to set the base opacity and the plugin will randomly generate snows with slightly varied opacity.
+  color: "#ffffff", // You can set the color of the snow here. This option only accepts HEX color code in full 6 digits. The default value is "#ffffff"
+  windPower: 0, // You can set the wind power here. If you want the wind to blow left, set a positive number in this option., if you want the wind to blow right, set a negative number in this option. The default value is 0.
+  image: false // You can define a path to an image to be used instead of a default circle here. The default value is false.
+});
+````
+
+If you want to change an option after inititing `let_it_snow` plugin you can trigger `letItSnow.set` event passing two arguments in the second parameter array: `["optionName", "optionValue"]`:
+
+````javascript
+$("canvas").trigger("letItSnow.set", ["windPower", 13]);
 ````
 
 And that's all for this plugin. Stay tuned for more updates.

--- a/demo/jquery.let_it_snow.js
+++ b/demo/jquery.let_it_snow.js
@@ -23,9 +23,8 @@
     color: "#ffffff",
     windPower: 0,
     image: false
-	};
-	
-  
+    };
+
   $.fn.let_it_snow = function(options){
     var settings = $.extend({}, defaults, options),
         el = $(this),
@@ -38,6 +37,10 @@
     
         canvas.width = window.innerWidth;
         canvas.height = window.innerHeight;
+
+        el.on("letItSnow.set", function (event, prop, value) {
+            settings[prop] = value;
+        });
         
     (function() {
         var requestAnimationFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame || window.msRequestAnimationFrame ||
@@ -186,7 +189,7 @@
     }
     
     init();
-    
+
     $(window).resize(function() {
       if(this.resizeTO) clearTimeout(this.resizeTO);
       this.resizeTO = setTimeout(function() {
@@ -206,4 +209,3 @@
     }
   }
 }(window.jQuery);
-

--- a/demo/let_it_snow_demo.html
+++ b/demo/let_it_snow_demo.html
@@ -225,6 +225,16 @@
     canvas.flare {
       opacity: 0.5;
     }
+
+    .snowWindPower {
+        padding: 10px;
+        width: 90px;
+        border: none;
+        border-radius: 3px;
+        font-size: 33px;
+        background: rgba(0, 0, 0, 0.31);
+        color: white;
+    }
 	</style>
 	<script>
 	  $(document).ready( function() {
@@ -243,6 +253,9 @@
     	      count: 250,
     	      size: 0
     	    });
+            $(".snowWindPower").on("change", function () {
+                $("canvas.snow").trigger("letItSnow", ["windPower", parseInt($(this).val())]);
+            });
 	  });
 		
 	</script>
@@ -256,6 +269,8 @@
         <h1>jQuery Let It Snow</h1>
         <h2>Create and Control a Festive Snow on Your Website using HTML5 Canvas</h2>
         <p class="credit">Created by <a href="http://www.thepetedesign.com">Pete R.</a>, Founder of <a href="http://www.bucketlistly.com" target="_blank">BucketListly</a></p>
+        <p class="credit">You can change the wind power setting the value of the following input (implemented by <a href="https://github.com/IonicaBizau" target="_blank">Ionică Bizău</a>):</p>
+        <input type="number" value="3" class="snowWindPower"> 
         <div class="btns">
   	      <a class="reload btn" href="https://github.com/peachananr/let_it_snow">Download on Github</a>
   	    </div>

--- a/jquery.let_it_snow.js
+++ b/jquery.let_it_snow.js
@@ -23,9 +23,8 @@
     color: "#ffffff",
     windPower: 0,
     image: false
-	};
-	
-  
+    };
+
   $.fn.let_it_snow = function(options){
     var settings = $.extend({}, defaults, options),
         el = $(this),
@@ -38,6 +37,10 @@
     
         canvas.width = window.innerWidth;
         canvas.height = window.innerHeight;
+
+        el.on("letItSnow.set", function (event, prop, value) {
+            settings[prop] = value;
+        });
         
     (function() {
         var requestAnimationFrame = window.requestAnimationFrame || window.mozRequestAnimationFrame || window.webkitRequestAnimationFrame || window.msRequestAnimationFrame ||
@@ -186,7 +189,7 @@
     }
     
     init();
-    
+
     $(window).resize(function() {
       if(this.resizeTO) clearTimeout(this.resizeTO);
       this.resizeTO = setTimeout(function() {
@@ -206,4 +209,3 @@
     }
   }
 }(window.jQuery);
-


### PR DESCRIPTION
If you want to change an option after inititing `let_it_snow` plugin you can trigger `letItSnow.set` event passing two arguments in the second parameter array: `["optionName", "optionValue"]`:

``` javascript
$("canvas").trigger("letItSnow.set", ["windPower", 13]);
```
